### PR TITLE
chore(ci): add Makefile for Exctract and add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: GHCR Release CI
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  tests:
+    name: Release new Docker Image in GHCR
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set current directory to Extract
+        run: cd extract
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{github.repository_owner}}
+          password: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Build Docker images for GHCR
+        run: make build_ghcr
+
+      - name: Push Docker images to GHCR
+        run: make push_ghcr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: GHCR Release CI
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-c2c.[0-9]+"
 
 jobs:
   tests:

--- a/extract/Makefile
+++ b/extract/Makefile
@@ -1,0 +1,29 @@
+VERSION ?= $(shell git describe --always --tags)
+DOCKER_TAG ?= latest
+
+export DOCKER_BUILDKIT=1
+
+.PHONY: build_docker
+build_docker: ## Build docker image
+	docker build --tag=camptocamp/asit-extract:$(VERSION) \
+		--build-arg=VERSION=$(VERSION) .
+	docker tag camptocamp/asit-extract:$(VERSION) camptocamp/asit-extract:$(DOCKER_TAG)
+
+.PHONY: build_ghcr
+build_ghcr: ## Build docker image tagged for GHCR
+	docker build --tag=ghcr.io/camptocamp/asit-extract:$(VERSION) \
+		--build-arg=VERSION=$(VERSION) .
+	docker tag ghcr.io/camptocamp/asit-extract:$(VERSION) ghcr.io/camptocamp/asit-extract:$(DOCKER_TAG)
+
+.PHONY: push_ghcr
+push_ghcr: ## Push docker image to GHCR
+	docker push ghcr.io/camptocamp/asit-extract:$(VERSION)
+	docker push ghcr.io/camptocamp/asit-extract:$(DOCKER_TAG)
+
+.PHONY: help
+help: ## Display this help
+	@echo "Usage: make <target>"
+	@echo
+	@echo "Available targets:"
+	@grep --extended-regexp --no-filename '^[a-zA-Z_-]+:.*## ' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "	%-20s%s\n", $$1, $$2}'

--- a/extract/Makefile
+++ b/extract/Makefile
@@ -3,6 +3,8 @@ DOCKER_TAG ?= latest
 
 export DOCKER_BUILDKIT=1
 
+.DEFAULT_GOAL := help
+
 .PHONY: build_docker
 build_docker: ## Build docker image
 	docker build --tag=camptocamp/asit-extract:$(VERSION) \


### PR DESCRIPTION
This PR add a release workflow for the Exctract application triggered on tag push matching with semantic versioning (x.y.z) 