### PR TITLE
feat: rootless image and custom properties

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,250 +1,245 @@
 networks:
-    default:
-    qnetwork:
+  default:
+  qnetwork:
 
 volumes:
   geoshop-files:
   zitadel-files:
 
 services:
+  # Frontend
+  frontend:
+    build: ./frontend
+    depends_on:
+      geoshop:
+        condition: service_healthy
+      extract:
+        condition: service_healthy
+    environment:
+      - FRONTEND_HOST=${FRONTEND_HOST:-localhost}
+      - FRONTEND_PORT=${FRONTEND_PORT:-8080}
+      - GEOSHOP_BACKEND=http://geoshop:8000
+      - EXTRACT_FRONTEND=http://extract:8080
+    volumes:
+      - geoshop-files:/geoshop/media/
+    ports:
+      - "8080:80"
+    healthcheck:
+      test: ( curl -L --fail http://localhost/extract | grep '<title>Extract</title>' && curl -L --fail http://localhost/geoshop ) || exit 1
+      interval: 10s
+      timeout: 10s
+      retries: 15
 
-    # Frontend
-    frontend:
-      build: ./frontend
-      depends_on:
-          geoshop:
-              condition: service_healthy
-          extract:
-              condition: service_healthy
-      environment:
-        - FRONTEND_HOST=${FRONTEND_HOST:-localhost}
-        - FRONTEND_PORT=${FRONTEND_PORT:-8080}
-        - GEOSHOP_BACKEND=http://geoshop:8000
-        - EXTRACT_FRONTEND=http://extract:8080
-      volumes:
-        - geoshop-files:/geoshop/media/
-      ports:
-        - "8080:80"
-      healthcheck:
-          test: ( curl -L --fail http://localhost/extract | grep '<title>Extract</title>' && curl -L --fail http://localhost/geoshop ) || exit 1
-          interval: 10s
-          timeout: 10s
-          retries: 15
+  # Extract
+  extract:
+    build: ./extract
+    depends_on:
+      pgsql:
+        condition: service_healthy
+      geodata:
+        condition: service_healthy
+    environment:
+      - JAVA_OPTS=-Xms1G -Xmx2G
+        -Duser.language=en -Duser.region=CH -Dcom.sun.jndi.ldap.connect.pool.timeout=20000
+      - ENCRYPTION_SECRET=12345678901234567890123456789012
+      - ENCRYPTION_SALT=12345678901234567890123456789012
+      - EXTERNAL_URL=http://localhost:8080/extract/
+    healthcheck:
+      test: curl -L --fail http://localhost:8080/extract || exit 1
+      interval: 10s
+      timeout: 10s
+      retries: 15
 
-    # Extract
-    extract:
-        build: ./extract
-        depends_on:
-            pgsql:
-                condition: service_healthy
-            geodata:
-                condition: service_healthy
-        environment:
-            - JAVA_OPTS=-Xms1G -Xmx2G
-              -Dspring.datasource.url="jdbc:postgresql://pgsql:5432/extract"
-              -Dspring.datasource.username=extractuser
-              -Dspring.datasource.password=demopassword
-              -Duser.language=en -Duser.region=CH -Dcom.sun.jndi.ldap.connect.pool.timeout=20000
-            - GEODATA_POSTGRES_HOST=geodata
-            - GEODATA_POSTGRES_DB=geodata
-            - GEODATA_POSTGRES_USER=extractuser
-            - GEODATA_POSTGRES_PASSWORD=demopassword
-        healthcheck:
-            test: curl -L --fail http://localhost:8080/extract || exit 1
-            interval: 10s
-            timeout: 10s
-            retries: 15
+  # Extract/Postgres
+  pgsql:
+    image: postgis/postgis:14-3.2-alpine
+    environment:
+      - POSTGRES_DB=extract
+      - POSTGRES_USER=extractuser
+      - POSTGRES_PASSWORD=demopassword
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U extractuser -d postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
-    # Extract/Postgres
-    pgsql:
-        image: postgis/postgis:14-3.2-alpine
-        environment:
-            - POSTGRES_DB=extract
-            - POSTGRES_USER=extractuser
-            - POSTGRES_PASSWORD=demopassword
-        healthcheck:
-            test: ["CMD-SHELL", "pg_isready -U extractuser -d postgres"]
-            interval: 5s
-            timeout: 5s
-            retries: 5
+  # Extract/Postgis
+  geodata:
+    image: postgis/postgis:14-3.2-alpine
+    environment:
+      - POSTGRES_DB=geodata
+      - POSTGRES_USER=extractuser
+      - POSTGRES_PASSWORD=demopassword
+    ports:
+      - "54320:5432"
+    volumes:
+      - ./extract/geodata:/docker-entrypoint-initdb.d/
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U extractuser -d postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
-    # Extract/Postgis
-    geodata:
-        image: postgis/postgis:14-3.2-alpine
-        environment:
-            - POSTGRES_DB=geodata
-            - POSTGRES_USER=extractuser
-            - POSTGRES_PASSWORD=demopassword
-        ports:
-            - "54320:5432"
-        volumes:
-          - ./extract/geodata:/docker-entrypoint-initdb.d/
-        healthcheck:
-            test: ["CMD-SHELL", "pg_isready -U extractuser -d postgres"]
-            interval: 5s
-            timeout: 5s
-            retries: 5
+  # Extract/Updatedb
+  updatedb:
+    image: postgis/postgis:14-3.2-alpine
+    depends_on:
+      extract:
+        condition: service_healthy
+    environment:
+      - PGHOST=pgsql
+      - PGDB=extract
+      - PGUSER=extractuser
+      - PGPASSWORD=demopassword
+      - GEOSHOP_BACKEND=http://geoshop:8000
+    volumes:
+      - ./updatedb:/updatedb
+    entrypoint: /updatedb/update.sh
 
-    # Extract/Updatedb
-    updatedb:
-        image: postgis/postgis:14-3.2-alpine
-        depends_on:
-            extract:
-                condition: service_healthy
-        environment:
-            - PGHOST=pgsql
-            - PGDB=extract
-            - PGUSER=extractuser
-            - PGPASSWORD=demopassword
-            - GEOSHOP_BACKEND=http://geoshop:8000
-        volumes:
-            - ./updatedb:/updatedb
-        entrypoint: /updatedb/update.sh
+  # Geoshop
+  geoshop:
+    build: ./geoshop/back
+    depends_on:
+      postgis:
+        condition: service_healthy
+    env_file: ./geoshop/${TEST_MODE+test}.env
+    volumes:
+      - geoshop-files:/geoshop/files
+      - zitadel-files:/zitadel-files
+    healthcheck:
+      test: curl -L --fail http://localhost:8000 || exit 1
+      interval: 10s
+      timeout: 10s
+      retries: 15
 
-    # Geoshop
-    geoshop:
-        build: ./geoshop/back
-        depends_on:
-            postgis:
-                condition: service_healthy
-        env_file: ./geoshop/${TEST_MODE+test}.env
-        volumes:
-            - geoshop-files:/geoshop/files
-            - zitadel-files:/zitadel-files
-        healthcheck:
-            test: curl -L --fail http://localhost:8000 || exit 1
-            interval: 10s
-            timeout: 10s
-            retries: 15
+  # Geoshop Front End
+  # TODO: use env variables for the backend url and port
+  geoshop_fe:
+    build: ./geoshop/front
+    depends_on:
+      geoshop:
+        condition: service_healthy
+    ports:
+      # TODO repalce prot with env variable
+      - "8085:8080"
 
-    # Geoshop Front End
-    # TODO: use env variables for the backend url and port
-    geoshop_fe:
-        build: ./geoshop/front
-        depends_on:
-            geoshop:
-                condition: service_healthy
-        ports:
-        # TODO repalce prot with env variable
-            - "8085:8080"
+  # Geoshop/Postgis
+  postgis:
+    image: postgis/postgis:14-3.2-alpine
+    volumes:
+      - ./geoshop/resources/ini-scripts:/docker-entrypoint-initdb.d/:ro
+      - ./geoshop/resources/postgis_data:/var/lib/postgresql/data:rw
+    environment:
+      LANG: "en_US.utf8"
+      LC_COLLATE: "en_US.utf8"
+      LC_CTYPE: "en_US.utf8"
+    env_file: ./geoshop/.env
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U geoshop"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
-    # Geoshop/Postgis
-    postgis:
-        image: postgis/postgis:14-3.2-alpine
-        volumes:
-          - ./geoshop/resources/ini-scripts:/docker-entrypoint-initdb.d/:ro
-          - ./geoshop/resources/postgis_data:/var/lib/postgresql/data:rw
-        environment:
-            LANG: 'en_US.utf8'
-            LC_COLLATE: 'en_US.utf8'
-            LC_CTYPE: 'en_US.utf8'
-        env_file: ./geoshop/.env
-        ports:
-            - "5432:5432"
-        healthcheck:
-            test: ["CMD-SHELL", "pg_isready -U geoshop"]
-            interval: 5s
-            timeout: 5s
-            retries: 5
+  # Mailhog
+  mailhog:
+    image: mailhog/mailhog
+    tty: true
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+    volumes:
+      - ./mailhog:/home/mailhog/conf
+    entrypoint: MailHog -auth-file=/home/mailhog/conf/auth-users
 
-    # Mailhog
-    mailhog:
-        image: mailhog/mailhog
-        tty: true
-        ports:
-            - "1025:1025"
-            - "8025:8025"
-        volumes:
-            - ./mailhog:/home/mailhog/conf
-        entrypoint: MailHog -auth-file=/home/mailhog/conf/auth-users
+  # LDAP
+  openldap:
+    image: osixia/openldap:1.5.0
+    environment:
+      - LDAP_ORGANISATION=Extract
+      - LDAP_DOMAIN=extract.org
+      - LDAP_ADMIN_PASSWORD=extract
+      - LDAP_CONFIG_PASSWORD=extract
+      - LDAP_RFC2307BIS_SCHEMA=true
+      - LDAP_REMOVE_CONFIG_AFTER_SETUP=true
+      - LDAP_TLS_VERIFY_CLIENT=try
+    ports:
+      - "389:389"
+      - "636:636"
 
-    # LDAP
-    openldap:
-        image: osixia/openldap:1.5.0
-        environment:
-            - LDAP_ORGANISATION=Extract
-            - LDAP_DOMAIN=extract.org
-            - LDAP_ADMIN_PASSWORD=extract
-            - LDAP_CONFIG_PASSWORD=extract
-            - LDAP_RFC2307BIS_SCHEMA=true
-            - LDAP_REMOVE_CONFIG_AFTER_SETUP=true
-            - LDAP_TLS_VERIFY_CLIENT=try
-        ports:
-            - "389:389"
-            - "636:636"
+  ldap-ad:
+    build: ./ldap-ad
+    volumes:
+      - ./ldap-ad/users.ldif:/ldap/users.ldif
+    ports:
+      - "10389:10389"
 
-    ldap-ad:
-        build: ./ldap-ad
-        volumes:
-            - ./ldap-ad/users.ldif:/ldap/users.ldif
-        ports:
-            - "10389:10389"
+  # QGIS
+  qgisserver:
+    image: camptocamp/qgis-server
+    volumes:
+      - ./qgis/project:/etc/qgisserver
+    environment:
+      - QGIS_PROJECT_FILE=/etc/qgisserver/world.qgs
+      - QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES=/etc/qgisserver
+    networks:
+      - qnetwork
 
-    # QGIS
-    qgisserver:
-        image: camptocamp/qgis-server
-        volumes:
-            - ./qgis/project:/etc/qgisserver
-        environment:
-            - QGIS_PROJECT_FILE=/etc/qgisserver/world.qgs
-            - QGIS_SERVER_LANDING_PAGE_PROJECTS_DIRECTORIES=/etc/qgisserver
-        networks:
-            - qnetwork
+  qgisproxy:
+    depends_on:
+      qgisserver:
+        condition: service_started
+    build:
+      context: ./qgis
+    hostname: qgisproxy
+    container_name: qgisproxy
+    volumes:
+      - ./qgis/nginx.conf:/etc/nginx/nginx/conf:ro
+    ports:
+      - 8888:80
+    networks:
+      - qnetwork
+      - default
 
-    qgisproxy:
-        depends_on:
-            qgisserver:
-                condition: service_started
-        build:
-            context: ./qgis
-        hostname: qgisproxy
-        container_name: qgisproxy
-        volumes:
-            - ./qgis/nginx.conf:/etc/nginx/nginx/conf:ro
-        ports:
-            - 8888:80
-        networks:
-            - qnetwork
-            - default
+  test:
+    profiles: [testing]
+    build: ./tests
+    environment:
+      - GEOSHOP_DEMO_LOGIN=${GEOSHOP_DEMO_LOGIN}
+      - EXTRACT_DEMO_LOGIN=${EXTRACT_DEMO_LOGIN}
+      - ZITADEL_DEMO_LOGIN=${ZITADEL_DEMO_LOGIN}
+      - TEST_OUTPUT=${TEST_OUTPUT:-/test_output/}
+    volumes:
+      - ./test_output:${TEST_OUTPUT:-/test_output/}
+    depends_on:
+      selenium:
+        condition: service_healthy
+      frontend:
+        condition: service_healthy
+      zitadel:
+        condition: service_started
 
-    test:
-        profiles: [testing]
-        build: ./tests
-        environment:
-            - GEOSHOP_DEMO_LOGIN=${GEOSHOP_DEMO_LOGIN}
-            - EXTRACT_DEMO_LOGIN=${EXTRACT_DEMO_LOGIN}
-            - ZITADEL_DEMO_LOGIN=${ZITADEL_DEMO_LOGIN}
-            - TEST_OUTPUT=${TEST_OUTPUT:-/test_output/}
-        volumes:
-          - ./test_output:${TEST_OUTPUT:-/test_output/}
-        depends_on:
-            selenium:
-                condition: service_healthy
-            frontend:
-                condition: service_healthy
-            zitadel:
-                condition: service_started
+  selenium:
+    profiles: [testing]
+    image: selenium/standalone-firefox
+    ports:
+      - 5900:5900
+    healthcheck:
+      test: curl --fail http://localhost:4444/ || exit 1
+      interval: 10s
+      timeout: 10s
+      retries: 15
 
-    selenium:
-        profiles: [testing]
-        image: selenium/standalone-firefox
-        ports:
-            - 5900:5900
-        healthcheck:
-            test: curl --fail http://localhost:4444/ || exit 1
-            interval: 10s
-            timeout: 10s
-            retries: 15
-
-    zitadel:
-        build: zitadel
-        volumes:
-          - zitadel-files:/zitadel/files
-        ports:
-          - 9998:9998
-        environment:
-            - PORT=9998
-            - USERS_FILE=/zitadel/users.json
-            - ISSUER=http://zitadel:9998
-            - DEV_MODE=true
-            - REDIRECT_URIS=http://frontend/geoshop/oidc/callback,https://frontend:80/geoshop/oidc/callback,http://frontend:80/geoshop/oidc/callback,http://frontend/geoshop/auth/oidc
+  zitadel:
+    build: zitadel
+    volumes:
+      - zitadel-files:/zitadel/files
+    ports:
+      - 9998:9998
+    environment:
+      - PORT=9998
+      - USERS_FILE=/zitadel/users.json
+      - ISSUER=http://zitadel:9998
+      - DEV_MODE=true
+      - REDIRECT_URIS=http://frontend/geoshop/oidc/callback,https://frontend:80/geoshop/oidc/callback,http://frontend:80/geoshop/oidc/callback,http://frontend/geoshop/auth/oidc

--- a/extract/Dockerfile
+++ b/extract/Dockerfile
@@ -60,5 +60,5 @@ COPY tomcat/conf/context.xml /usr/local/tomcat/conf/context.xml
 COPY script.py /extract/script.py
 
 RUN mkdir -p /var/log/extract
-RUN chown -R www-data:www-data /usr/local/tomcat/ /var/log/extract/
+RUN chown -R www-data:www-data /usr/local/tomcat/ /var/log/extract/ /var/extract/orders /extract/
 USER 33

--- a/extract/Dockerfile
+++ b/extract/Dockerfile
@@ -16,6 +16,9 @@ RUN apt-get update && \
 
 COPY extract-task-exec /extract-build/extract-task-exec
 
+# Copy custom application.properties file to the build folder
+COPY config/application.properties /extract-build/application.properties
+
 RUN cd /extract-build/sitn_geoshop_connector/ && git checkout "${GEOSHOP_CONNECTOR_VERSION}" && \
     cd /extract-build/sitn_geoshop_connector/plugin-interface && \
     mvn clean install && \
@@ -23,6 +26,7 @@ RUN cd /extract-build/sitn_geoshop_connector/ && git checkout "${GEOSHOP_CONNECT
     mvn clean install && \
     cp target/extract-connector-geoshop-*.jar /extract-build/extract/extract/src/main/resources/connectors && \
     cd /extract-build/extract/ && git checkout "${EXTRACT_VERSION}" && \
+    cp /extract-build/application.properties /extract-build/extract/extract/src/main/resources/application.properties && \
     cd /extract-build/extract/extract-interface && \
     mvn clean install && \
     cd /extract-build/extract-task-exec && \
@@ -40,6 +44,14 @@ RUN cd /extract-build/extract/ && git checkout "${EXTRACT_VERSION}" && \
 # Extract service
 FROM tomcat:9.0.64-jre17
 LABEL Maintainer="andrey.rusakov@camptocamp.com" Vendor="Camptocamp"
+
+ENV GEODATA_POSTGRES_HOST="${GEODATA_POSTGRES_HOST:-pgsql}" \
+    GEODATA_POSTGRES_PORT="${GEODATA_POSTGRES_PORT:-5432}" \
+    GEODATA_POSTGRES_USER="${GEODATA_POSTGRES_USER:-extractuser}" \
+    GEODATA_POSTGRES_PASSWORD="${GEODATA_POSTGRES_PASSWORD:-demopassword}" \
+    GEODATA_POSTGRES_DB="${GEODATA_POSTGRES_DB:-extract}" \
+    EXTERNAL_URL="${EXTERNAL_URL:-http://localhost:8080}"
+
 RUN apt update && apt upgrade -y && \
     apt install -y curl python3 python3-psycopg2 && \
     mkdir -p /var/extract/orders && mkdir -p /extract/

--- a/extract/Dockerfile
+++ b/extract/Dockerfile
@@ -46,3 +46,7 @@ RUN apt update && apt upgrade -y && \
 COPY --from=builder /extract-build/extract-*.war /usr/local/tomcat/webapps/extract.war
 COPY tomcat/conf/context.xml /usr/local/tomcat/conf/context.xml
 COPY script.py /extract/script.py
+
+RUN mkdir -p /var/log/extract
+RUN chown -R www-data:www-data /usr/local/tomcat/ /var/log/extract/
+USER 33

--- a/extract/config/application.properties
+++ b/extract/config/application.properties
@@ -1,0 +1,52 @@
+# Default properties for database persistence
+spring.datasource.url=jdbc:postgresql://${GEODATA_POSTGRES_HOST}:${GEODATA_POSTGRES_PORT}/${GEODATA_POSTGRES_DB}
+spring.datasource.username=${GEODATA_POSTGRES_USER}
+spring.datasource.password=${GEODATA_POSTGRES_PASSWORD}
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.show-sql=false
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.id.new_generator_mappings=true
+
+# Do not start batch job execution as soon as the application is started, use scheduler instead
+spring.batch.job.enabled=false
+spring.batch.jdbc.initialize-schema=never
+
+# Maximum size of uploaded files
+spring.servlet.multipart.max-file-size = 1024MB
+spring.servlet.multipart.max-request-size = 1024MB
+
+database.encryption.secret=${ENCRYPTION_SECRET}
+database.encryption.salt=${ENCRYPTION_SALT}
+
+ldap.attributes.login=sAMAccountName
+ldap.attributes.mail=mail
+ldap.attributes.fullname=cn
+ldap.user.objectclass=person
+
+logging.config=classpath:logback-spring.xml
+
+extract.i18n.language=fr
+
+spring.thymeleaf.cache=false
+spring.thymeleaf.enabled=true
+spring.thymeleaf.encoding=UTF-8
+spring.thymeleaf.mode=HTML
+spring.thymeleaf.prefix=classpath:/templates/pages/
+spring.thymeleaf.suffix=.html
+spring.thymeleaf.template-resolver-order=1
+
+email.templates.cache=false
+email.templates.path=classpath:/templates/email/
+email.templates.encoding=UTF-8
+
+application.external.url=${EXTERNAL_URL}
+
+table.page.size=10
+
+#If you need a proxy to connect external URL you can set its parameters with the following properties. If your proxy
+#does not require to authenticate, you can leave http.proxyUser and http.proxyPassword commented (or delete the lines)
+#http.proxyHost=myproxy.mydomain.com
+#http.proxyPort=8080
+#http.proxyUser=myProxyUser
+#http.proxyPassword=myProxyPassword

--- a/test.env
+++ b/test.env
@@ -5,3 +5,4 @@ GEOSHOP_DEMO_LOGIN=admin:Test1234
 EXTRACT_DEMO_LOGIN=admin:motdepasse21
 ZITADEL_DEMO_LOGIN=oidc-user@camptocamp.ch:password
 TEST_OUTPUT=/test_output
+EXTERNAL_URL=http://frontend/extract/


### PR DESCRIPTION
With this PR I've done two major changes to the extract image:
- The final image is now rootless, it will now run with UID 33 (www-data) and I changed ownership of `/usr/local/tomcat/` `/var/log/extract/` directories 
- I added a custom `application.properties` file which is now use to override the default one during the build process. This file now use env variables for database, security and external domain configuration in order to improve the configuration process and avoid clear secrets in flags