### PR TITLE
build: redure image size by removing unused packages

### DIFF
--- a/extract/Dockerfile
+++ b/extract/Dockerfile
@@ -41,7 +41,7 @@ RUN cd /extract-build/extract/ && git checkout "${EXTRACT_VERSION}" && \
 FROM tomcat:9.0.64-jre17
 LABEL Maintainer="andrey.rusakov@camptocamp.com" Vendor="Camptocamp"
 RUN apt update && apt upgrade -y && \
-    apt install -y curl python3 python3-gdal python3-psycopg2 python3-geopandas python3-psycopg2 && \
+    apt install -y curl python3 python3-psycopg2 && \
     mkdir -p /var/extract/orders && mkdir -p /extract/
 COPY --from=builder /extract-build/extract-*.war /usr/local/tomcat/webapps/extract.war
 COPY tomcat/conf/context.xml /usr/local/tomcat/conf/context.xml


### PR DESCRIPTION
I removed unused `python3-gdal` and `python3-geopandas` packages to reduce the image size which was about 2.4Gb and is now ~750Mb 