### PR TITLE
Bump tag to 2.3.0-c2c.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Geoshop docker package
 =====
-Extract v2.3.1-c2c.1
+Extract v2.3.1-c2c.2
 
 ## Demo and the config for Extract and Geoshop
 


### PR DESCRIPTION
Needed to force github rebuild the docker image.